### PR TITLE
create empty file during error routing 

### DIFF
--- a/flow/flow.cal.asgn/flow.cal.asgn.R
+++ b/flow/flow.cal.asgn/flow.cal.asgn.R
@@ -209,20 +209,22 @@ foreach::foreach(idxDirIn = DirIn) %dopar% {
                     log=log
       ),
       error = function(err) {
-        call.stack <- sys.calls() # is like a traceback within "withCallingHandlers"
-        log$error(base::paste0('The following error has occurred (call stack to follow): ',err))
-        print(utils::limitedLabels(call.stack))
-      }
-    ),
-    error=function(err) {
-      NEONprocIS.base::def.err.datm(
+        call.stack <- base::sys.calls() # is like a traceback within "withCallingHandlers"
+        
+        # Re-route the failed datum
+        NEONprocIS.base::def.err.datm(
+          err=err,
+          call.stack=call.stack,
           DirDatm=idxDirIn,
           DirErrBase=Para$DirErr,
           RmvDatmOut=FALSE,
           DirOutBase=Para$DirOut,
           log=log
         )
-    }
+      }
+    ),
+    # This simply to avoid returning the error
+    error=function(err) {}
   )
   
   return()

--- a/flow/flow.cal.conv/flow.cal.conv.R
+++ b/flow/flow.cal.conv/flow.cal.conv.R
@@ -458,20 +458,22 @@ foreach::foreach(idxDirIn = DirIn) %dopar% {
                          log=log
       ),
       error = function(err) {
-        call.stack <- sys.calls() # is like a traceback within "withCallingHandlers"
-        log$error(base::paste0('The following error has occurred (call stack to follow): ',err))
-        print(utils::limitedLabels(call.stack))
-      }
-    ),
-    error=function(err) {
-      NEONprocIS.base::def.err.datm(
+        call.stack <- base::sys.calls() # is like a traceback within "withCallingHandlers"
+        
+        # Re-route the failed datum
+        NEONprocIS.base::def.err.datm(
+          err=err,
+          call.stack=call.stack,
           DirDatm=idxDirIn,
           DirErrBase=Para$DirErr,
           RmvDatmOut=TRUE,
           DirOutBase=Para$DirOut,
           log=log
-      )
-    }
+        )
+      }
+    ),
+    # This simply to avoid returning the error
+    error=function(err) {}
   )
   
   return()

--- a/flow/flow.data.comb.ts/Dockerfile
+++ b/flow/flow.data.comb.ts/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for NEON IS Data Processing - Combine Timeseries Data
 
 # Start with the base image. 
-FROM quay.io/battelleecology/neon-is-base-r:v1.0.3
+FROM quay.io/battelleecology/neon-is-base-r:v1.0.4
 
 # maintainer handle
 MAINTAINER "Cove Sturtevant" csturtevant@battelleecology.org

--- a/flow/flow.data.comb.ts/flow.data.comb.ts.R
+++ b/flow/flow.data.comb.ts/flow.data.comb.ts.R
@@ -244,14 +244,13 @@ foreach::foreach(idxDirIn = DirIn) %dopar% {
         DirSubCopy=DirSubCopy,
         log=log
         ),
-        error = function(err) {
-          call.stack <- sys.calls() # is like a traceback within "withCallingHandlers"
-          log$error(base::paste0('The following error has occurred (call stack to follow): ',err))
-          print(utils::limitedLabels(call.stack))
-        }
-      ),
-      error=function(err) {
+      error = function(err) {
+        call.stack <- base::sys.calls() # is like a traceback within "withCallingHandlers"
+        
+        # Re-route the failed datum
         NEONprocIS.base::def.err.datm(
+          err=err,
+          call.stack=call.stack,
           DirDatm=idxDirIn,
           DirErrBase=Para$DirErr,
           RmvDatmOut=TRUE,
@@ -259,8 +258,11 @@ foreach::foreach(idxDirIn = DirIn) %dopar% {
           log=log
         )
       }
-    )
-    
+    ),
+    # This simply to avoid returning the error
+    error=function(err) {}
+  )
+  
     return()
     
 } # End loop around datum paths

--- a/flow/flow.loc.asgn/Dockerfile
+++ b/flow/flow.loc.asgn/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for NEON IS Data Processing - Calibration assignment
 
 # Start with the base image. 
-FROM quay.io/battelleecology/neon-is-base-r:v1.0.3
+FROM quay.io/battelleecology/neon-is-base-r:v1.0.4
 
 # maintainer handle
 MAINTAINER "Cove Sturtevant" csturtevant@battelleecology.org

--- a/flow/flow.loc.data.trnc.comb/Dockerfile
+++ b/flow/flow.loc.data.trnc.comb/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for NEON IS Data Processing - Truncate and merge data files by location
 
 # Start with the base image. 
-FROM quay.io/battelleecology/neon-is-base-r:v1.0.3
+FROM quay.io/battelleecology/neon-is-base-r:v1.0.4
 
 # maintainer handle
 MAINTAINER "Cove Sturtevant" csturtevant@battelleecology.org

--- a/flow/flow.loc.data.trnc.comb/flow.loc.data.trnc.comb.R
+++ b/flow/flow.loc.data.trnc.comb/flow.loc.data.trnc.comb.R
@@ -188,21 +188,24 @@ foreach::foreach(idxDirIn = DirIn) %dopar% {
                               log=log
       ),
       error = function(err) {
-        call.stack <- sys.calls() # is like a traceback within "withCallingHandlers"
-        log$error(base::paste0('The following error has occurred (call stack to follow): ',err))
-        print(utils::limitedLabels(call.stack))
+        call.stack <- base::sys.calls() # is like a traceback within "withCallingHandlers"
+        
+        # Re-route the failed datum
+        NEONprocIS.base::def.err.datm(
+          err=err,
+          call.stack=call.stack,
+          DirDatm=idxDirIn,
+          DirErrBase=Para$DirErr,
+          RmvDatmOut=TRUE,
+          DirOutBase=Para$DirOut,
+          log=log
+        )
       }
     ),
-    error=function(err) {
-      NEONprocIS.base::def.err.datm(
-        DirDatm=idxDirIn,
-        DirErrBase=Para$DirErr,
-        RmvDatmOut=TRUE,
-        DirOutBase=Para$DirOut,
-        log=log
-      )
-    }
+    # This simply to avoid returning the error
+    error=function(err) {}
   )
+  
   
   return()
   

--- a/flow/flow.loc.repo.strc/Dockerfile
+++ b/flow/flow.loc.repo.strc/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for NEON IS Data Processing - Restructure repo by location
 
 # Start with the base image. 
-FROM quay.io/battelleecology/neon-is-base-r:v1.0.3
+FROM quay.io/battelleecology/neon-is-base-r:v1.0.4
 
 # maintainer handle
 MAINTAINER "Cove Sturtevant" csturtevant@battelleecology.org

--- a/flow/flow.loc.repo.strc/flow.loc.repo.strc.R
+++ b/flow/flow.loc.repo.strc/flow.loc.repo.strc.R
@@ -177,21 +177,24 @@ foreach::foreach(idxDirIn = DirIn) %dopar% {
                          log=log
       ),
       error = function(err) {
-        call.stack <- sys.calls() # is like a traceback within "withCallingHandlers"
-        log$error(base::paste0('The following error has occurred (call stack to follow): ',err))
-        print(utils::limitedLabels(call.stack))
+        call.stack <- base::sys.calls() # is like a traceback within "withCallingHandlers"
+        
+        # Re-route the failed datum
+        NEONprocIS.base::def.err.datm(
+          err=err,
+          call.stack=call.stack,
+          DirDatm=idxDirIn,
+          DirErrBase=Para$DirErr,
+          RmvDatmOut=TRUE,
+          DirOutBase=Para$DirOut,
+          log=log
+        )
       }
     ),
-    error=function(err) {
-      NEONprocIS.base::def.err.datm(
-        DirDatm=idxDirIn,
-        DirErrBase=Para$DirErr,
-        RmvDatmOut=TRUE,
-        DirOutBase=Para$DirOut,
-        log=log
-      )
-    }
+    # This simply to avoid returning the error
+    error=function(err) {}
   )
+  
   
   return()
   

--- a/flow/flow.qaqc.data.comb/Dockerfile
+++ b/flow/flow.qaqc.data.comb/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for NEON IS Data Processing - Merge QC-filtered data files
 
 # Start with the base image. 
-FROM quay.io/battelleecology/neon-is-base-r:v1.0.3
+FROM quay.io/battelleecology/neon-is-base-r:v1.0.4
 
 # maintainer handle
 MAINTAINER "Cove Sturtevant" csturtevant@battelleecology.org

--- a/flow/flow.qaqc.plau/flow.qaqc.plau.R
+++ b/flow/flow.qaqc.plau/flow.qaqc.plau.R
@@ -252,21 +252,24 @@ foreach::foreach(idxDirIn = DirIn) %dopar% {
                      log=log
       ),
       error = function(err) {
-        call.stack <- sys.calls() # is like a traceback within "withCallingHandlers"
-        log$error(base::paste0('The following error has occurred (call stack to follow): ',err))
-        print(utils::limitedLabels(call.stack))
+        call.stack <- base::sys.calls() # is like a traceback within "withCallingHandlers"
+        
+        # Re-route the failed datum
+        NEONprocIS.base::def.err.datm(
+          err=err,
+          call.stack=call.stack,
+          DirDatm=idxDirIn,
+          DirErrBase=Para$DirErr,
+          RmvDatmOut=TRUE,
+          DirOutBase=Para$DirOut,
+          log=log
+        )
       }
     ),
-    error=function(err) {
-      NEONprocIS.base::def.err.datm(
-        DirDatm=idxDirIn,
-        DirErrBase=Para$DirErr,
-        RmvDatmOut=TRUE,
-        DirOutBase=Para$DirOut,
-        log=log
-      )
-    }
+    # This simply to avoid returning the error
+    error=function(err) {}
   )
+  
   
   return()
   

--- a/flow/flow.qaqc.qm.dp0p/flow.qaqc.qm.dp0p.R
+++ b/flow/flow.qaqc.qm.dp0p/flow.qaqc.qm.dp0p.R
@@ -494,21 +494,24 @@ foreach::foreach(idxDirIn = DirIn) %dopar% {
                         log=log
       ),
       error = function(err) {
-        call.stack <- sys.calls() # is like a traceback within "withCallingHandlers"
-        log$error(base::paste0('The following error has occurred (call stack to follow): ',err))
-        print(utils::limitedLabels(call.stack))
+        call.stack <- base::sys.calls() # is like a traceback within "withCallingHandlers"
+        
+        # Re-route the failed datum
+        NEONprocIS.base::def.err.datm(
+          err=err,
+          call.stack=call.stack,
+          DirDatm=idxDirIn,
+          DirErrBase=Para$DirErr,
+          RmvDatmOut=TRUE,
+          DirOutBase=Para$DirOut,
+          log=log
+        )
       }
     ),
-    error=function(err) {
-      NEONprocIS.base::def.err.datm(
-        DirDatm=idxDirIn,
-        DirErrBase=Para$DirErr,
-        RmvDatmOut=TRUE,
-        DirOutBase=Para$DirOut,
-        log=log
-      )
-    }
+    # This simply to avoid returning the error
+    error=function(err) {}
   )
+  
   
   return()
 } # End loop around datum paths

--- a/flow/flow.qaqc.qm/flow.qaqc.qm.R
+++ b/flow/flow.qaqc.qm/flow.qaqc.qm.R
@@ -519,21 +519,24 @@ foreach::foreach(idxDirIn = DirIn) %dopar% {
                    log=log
       ),
       error = function(err) {
-        call.stack <- sys.calls() # is like a traceback within "withCallingHandlers"
-        log$error(base::paste0('The following error has occurred (call stack to follow): ',err))
-        print(utils::limitedLabels(call.stack))
+        call.stack <- base::sys.calls() # is like a traceback within "withCallingHandlers"
+        
+        # Re-route the failed datum
+        NEONprocIS.base::def.err.datm(
+          err=err,
+          call.stack=call.stack,
+          DirDatm=idxDirIn,
+          DirErrBase=Para$DirErr,
+          RmvDatmOut=TRUE,
+          DirOutBase=Para$DirOut,
+          log=log
+        )
       }
     ),
-    error=function(err) {
-      NEONprocIS.base::def.err.datm(
-        DirDatm=idxDirIn,
-        DirErrBase=Para$DirErr,
-        RmvDatmOut=TRUE,
-        DirOutBase=Para$DirOut,
-        log=log
-      )
-    }
+    # This simply to avoid returning the error
+    error=function(err) {}
   )
+  
   
   return()
 } # End loop around datum paths 

--- a/flow/flow.qaqc.wq.sens.na/Dockerfile
+++ b/flow/flow.qaqc.wq.sens.na/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for NEON IS Data Processing - Water Quality Sensor NA test 
 
 # Start with the base image. 
-FROM quay.io/battelleecology/neon-is-base-r:v1.0.3
+FROM quay.io/battelleecology/neon-is-base-r:v1.0.4
 
 # maintainer handle
 MAINTAINER "Cove Sturtevant" csturtevant@battelleecology.org

--- a/flow/flow.rglr/Dockerfile
+++ b/flow/flow.rglr/Dockerfile
@@ -2,7 +2,7 @@
 
 # Start with the neon-is-base-r image. 
 # Use a multi-stage build to obscure the value of GITHUB_PAT used to install eddy4R.base
-FROM quay.io/battelleecology/neon-is-base-r:v1.0.3 as intermediate
+FROM quay.io/battelleecology/neon-is-base-r:v1.0.4 as intermediate
 
 # maintainer handle
 MAINTAINER "Cove Sturtevant" csturtevant@battelleecology.org
@@ -21,7 +21,7 @@ ENV GITHUB_PAT=$auth_token
 RUN git clone -b deve https://$GITHUB_PAT:x-oauth-basic@github.com/NEONScience/NEON-FIU-algorithm.git
 
 # Now make the final build, which will leave behind our access token
-FROM quay.io/battelleecology/neon-is-base-r:v1.0.3
+FROM quay.io/battelleecology/neon-is-base-r:v1.0.4
 
 # copy the eddy4R.base package from the previous image
 COPY --from=intermediate /NEON-FIU-algorithm/ext/eddy4R/pack/eddy4R.base/ /pack/eddy4R.base/

--- a/flow/flow.rglr/flow.rglr.R
+++ b/flow/flow.rglr/flow.rglr.R
@@ -447,21 +447,24 @@ foreach::foreach(idxDirIn = DirIn) %dopar% {
                 log=log
       ),
       error = function(err) {
-        call.stack <- sys.calls() # is like a traceback within "withCallingHandlers"
-        log$error(base::paste0('The following error has occurred (call stack to follow): ',err))
-        print(utils::limitedLabels(call.stack))
-      }
-    ),
-    error=function(err) {
-      NEONprocIS.base::def.err.datm(
+        call.stack <- base::sys.calls() # is like a traceback within "withCallingHandlers"
+        
+        # Re-route the failed datum
+        NEONprocIS.base::def.err.datm(
+          err=err,
+          call.stack=call.stack,
           DirDatm=idxDirIn,
           DirErrBase=Para$DirErr,
           RmvDatmOut=TRUE,
           DirOutBase=Para$DirOut,
           log=log
         )
-    }
+      }
+    ),
+    # This simply to avoid returning the error
+    error=function(err) {}
   )
+  
   
   return()
   

--- a/flow/flow.stat.basc/flow.stat.basc.R
+++ b/flow/flow.stat.basc/flow.stat.basc.R
@@ -277,21 +277,24 @@ foreach::foreach(idxDirIn = DirIn) %dopar% {
                      log=log
       ),
       error = function(err) {
-        call.stack <- sys.calls() # is like a traceback within "withCallingHandlers"
-        log$error(base::paste0('The following error has occurred (call stack to follow): ',err))
-        print(utils::limitedLabels(call.stack))
+        call.stack <- base::sys.calls() # is like a traceback within "withCallingHandlers"
+        
+        # Re-route the failed datum
+        NEONprocIS.base::def.err.datm(
+          err=err,
+          call.stack=call.stack,
+          DirDatm=idxDirIn,
+          DirErrBase=Para$DirErr,
+          RmvDatmOut=TRUE,
+          DirOutBase=Para$DirOut,
+          log=log
+        )
       }
     ),
-    error=function(err) {
-      NEONprocIS.base::def.err.datm(
-        DirDatm=idxDirIn,
-        DirErrBase=Para$DirErr,
-        RmvDatmOut=TRUE,
-        DirOutBase=Para$DirOut,
-        log=log
-      )
-    }
+    # This simply to avoid returning the error
+    error=function(err) {}
   )
+  
   
   return()
 } # End loop around datum paths 

--- a/flow/flow.thsh.slct/flow.thsh.slct.R
+++ b/flow/flow.thsh.slct/flow.thsh.slct.R
@@ -194,21 +194,24 @@ foreach::foreach(idxDirIn = DirIn) %dopar% {
                      log=log
       ),
       error = function(err) {
-        call.stack <- sys.calls() # is like a traceback within "withCallingHandlers"
-        log$error(base::paste0('The following error has occurred (call stack to follow): ',err))
-        print(utils::limitedLabels(call.stack))
+        call.stack <- base::sys.calls() # is like a traceback within "withCallingHandlers"
+        
+        # Re-route the failed datum
+        NEONprocIS.base::def.err.datm(
+          err=err,
+          call.stack=call.stack,
+          DirDatm=idxDirIn,
+          DirErrBase=Para$DirErr,
+          RmvDatmOut=TRUE,
+          DirOutBase=Para$DirOut,
+          log=log
+        )
       }
     ),
-    error=function(err) {
-      NEONprocIS.base::def.err.datm(
-        DirDatm=idxDirIn,
-        DirErrBase=Para$DirErr,
-        RmvDatmOut=TRUE,
-        DirOutBase=Para$DirOut,
-        log=log
-      )
-    }
+    # This simply to avoid returning the error
+    error=function(err) {}
   )
+  
   
   return()
   

--- a/flow/flow.tsdl.comb.splt/Dockerfile
+++ b/flow/flow.tsdl.comb.splt/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for NEON IS Data Processing - Combine Temperature Specific Depth Lakes data and split by HOR.VER
 
 # Start with the base image. 
-FROM quay.io/battelleecology/neon-is-base-r:v1.0.3
+FROM quay.io/battelleecology/neon-is-base-r:v1.0.4
 
 # maintainer handle
 MAINTAINER "Guy Litt" glitt@battelleecology.org, "Cove Sturtevant" csturtevant@battelleecology.org

--- a/pack/NEONprocIS.base/DESCRIPTION
+++ b/pack/NEONprocIS.base/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: NEONprocIS.base
 Title: Basic functions for NEON IS data processing
-Version: 0.0.40
+Version: 0.0.41
 Authors@R: 
     person(given = "Cove",
            family = "Sturtevant",

--- a/pack/NEONprocIS.base/man/def.err.datm.Rd
+++ b/pack/NEONprocIS.base/man/def.err.datm.Rd
@@ -5,6 +5,8 @@
 \title{Route datum errors to specified location}
 \usage{
 def.err.datm(
+  err = NULL,
+  call.stack = NULL,
   DirDatm,
   DirErrBase,
   RmvDatmOut = FALSE,
@@ -13,6 +15,10 @@ def.err.datm(
 )
 }
 \arguments{
+\item{err}{The error condition returned from a function call. For printing only. Defaults to NULL.}
+
+\item{call.stack}{The call stack returned from e.g. base::sys.calls(). For printing only. Defaults to NULL.}
+
 \item{DirDatm}{Character value. The input path to the datum, structured as follows: 
 #/pfs/BASE_REPO/#, where # indicates any number of parent and child directories 
 of any name, so long as they are not 'pfs'. Note that the path should terminate at 
@@ -52,7 +58,23 @@ DirDatm <- '/scratch/pfs/proc_group/prt/2019/01/01/27134'
 DirErrBase <- '/scratch/pfs/proc_group_output/errored_datums'
 RmvDatmOut <- TRUE
 DirOutBase <- '/scratch/pfs/proc_group_output'
-tryCatch(stop('error!'),error=function(err) def.err.datm(DirDatm=DirDatm,DirErrBase=DirErrBase,RmvDatmOut=RmvDatmOut,DirOutBase=DirOutBase))
+tryCatch(
+    withCallingHandlers(
+               stop('error!'),
+               error=function(err) {
+                       call.stack <- base::sys.calls() # is like a traceback within "withCallingHandlers"
+                       def.err.datm(err=err,
+                                    call.stack=call.stack,
+                                    DirDatm=DirDatm,
+                                    DirErrBase=DirErrBase,
+                                    RmvDatmOut=RmvDatmOut,
+                                    DirOutBase=DirOutBase)
+                                    )
+                       }
+               ),
+    error=function(err){print('I routed an error!')}
+    )
+    
 }
 \references{
 License: (example) GNU AFFERO GENERAL PUBLIC LICENSE Version 3, 19 November 2007

--- a/pack/NEONprocIS.base/man/def.time.miss.Rd
+++ b/pack/NEONprocIS.base/man/def.time.miss.Rd
@@ -11,7 +11,7 @@ def.time.miss(TimeBgn, TimeEnd, timeFull, log = NULL)
 
 \item{TimeEnd}{A POSIXct timestamp of the end date of interest (exclusive)}
 
-\item{timeFull}{A data frame of non-overlapping time ranges considered covered, with columns: \cr
+\item{timeFull}{A data frame of time ranges considered covered, with columns: \cr
 \code{timeBgn} POSIXct timestamps of the start date of the time range (inclusive)\cr
 \code{timeEnd} POSIXct timestamps of the end date of the time range (exclusive)\cr}
 

--- a/pack/NEONprocIS.cal/Dockerfile
+++ b/pack/NEONprocIS.cal/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for NEON IS Data Processing - Calibration package
 
 # Start with the neon-is-base-r image. 
-FROM quay.io/battelleecology/neon-is-base-r:v1.0.3
+FROM quay.io/battelleecology/neon-is-base-r:v1.0.4
 
 # maintainer handle
 MAINTAINER "Cove Sturtevant" csturtevant@battelleecology.org

--- a/pack/NEONprocIS.qaqc/Dockerfile
+++ b/pack/NEONprocIS.qaqc/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for NEON IS Data Processing - QAQC package
 
 # Start with the neon-is-base-r image. # Use a multi-stage build to obscure the value of GITHUB_PAT used to install eddy4R.base & eddy4R.qaqc
-FROM quay.io/battelleecology/neon-is-base-r:v1.0.3 as intermediate
+FROM quay.io/battelleecology/neon-is-base-r:v1.0.4 as intermediate
 
 # maintainer handle
 MAINTAINER "Cove Sturtevant" csturtevant@battelleecology.org
@@ -23,7 +23,7 @@ ENV GITHUB_PAT=$auth_token
 RUN git clone -b def.plau.impr.velo https://$GITHUB_PAT:x-oauth-basic@github.com/covesturtevant/NEON-FIU-algorithm-covesturtevant.git
 
 # Now make the final build, which will leave behind our access token
-FROM quay.io/battelleecology/neon-is-base-r:v1.0.3
+FROM quay.io/battelleecology/neon-is-base-r:v1.0.4
 
 # copy the eddy4R.base package from the previous image
 #COPY --from=intermediate /NEON-FIU-algorithm/ext/eddy4R/pack/eddy4R.base/ /pack/eddy4R.base/

--- a/pack/NEONprocIS.stat/Dockerfile
+++ b/pack/NEONprocIS.stat/Dockerfile
@@ -1,7 +1,7 @@
 # Dockerfile for NEON IS Data Processing - Calibration package
 
 # Start with the neon-is-base-r image. 
-FROM quay.io/battelleecology/neon-is-base-r:v1.0.3
+FROM quay.io/battelleecology/neon-is-base-r:v1.0.4
 
 # maintainer handle
 MAINTAINER "Cove Sturtevant" csturtevant@battelleecology.org


### PR DESCRIPTION
pachyderm 2.x will not write empty folders to the output. Writing an empty file solves this.