### PR TITLE
visibility added to group_loader output

### DIFF
--- a/modules/data_access/get_group_loader_properties.py
+++ b/modules/data_access/get_group_loader_properties.py
@@ -18,7 +18,8 @@ def get_group_loader_properties(connector: DbConnector, group_id: int) -> List[P
         select
             g.group_name,
             g.hor,
-            g.ver
+            g.ver, 
+            g.visibility_code
         from
             "group" g
         where
@@ -27,6 +28,7 @@ def get_group_loader_properties(connector: DbConnector, group_id: int) -> List[P
     properties: List[Property] = []
     hor_name = "HOR"
     ver_name = "VER"
+    visibility_code_name = "VISIBILITY_CODE"
     connection = connector.get_connection()
     with closing(connection.cursor()) as cursor:
         cursor.execute(sql, [group_id])
@@ -35,6 +37,8 @@ def get_group_loader_properties(connector: DbConnector, group_id: int) -> List[P
             # name = row[0]
             hor = row[1]
             ver = row[2]
+            visibility_code = row[3]
             properties.append(Property(name=hor_name, value=hor))
             properties.append(Property(name=ver_name, value=ver))
+            properties.append(Property(name=visibility_code_name, value=visibility_code))
     return properties

--- a/pipe/pressureAir/pressureAir_group_loader.yaml
+++ b/pipe/pressureAir/pressureAir_group_loader.yaml
@@ -7,7 +7,7 @@ transform:
     GROUP_PREFIX: pressure-air_
     LOG_LEVEL: INFO
     OUT_PATH: /pfs/out
-  image: quay.io/battelleecology/group_loader:515
+  image: quay.io/battelleecology/group_loader:520
   image_pull_secrets:
     - battelleecology-quay-read-all-pull-secret
   secrets:

--- a/pipe/test-group/group_loader_test-gcp.yaml
+++ b/pipe/test-group/group_loader_test-gcp.yaml
@@ -4,14 +4,14 @@ pipeline:
 transform:
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
-  image: quay.io/battelleecology/group_loader:515
+  image: quay.io/battelleecology/group_loader:520
   cmd:
   - /bin/bash
   stdin:
   - '#!/bin/bash'
   - python3 -m group_loader.group_loader_main
   env:
-    GROUP_PREFIX: pressure-air-
+    GROUP_PREFIX: test-group-
     OUT_PATH: /pfs/out
     LOG_LEVEL: INFO
   secrets:


### PR DESCRIPTION
@covesturtevant , 

"visibility" is added to group_loader output json.  The good build is 520.  
The test output files are copied to som,  /scratch/pfs/group-loader-gcp_B520, fyi.   