### PR TITLE
Update the group_loader Dockfile and build script to work with github actions and at the top level of NEON_IS_data_processing

### DIFF
--- a/modules/group_loader/Dockerfile
+++ b/modules/group_loader/Dockerfile
@@ -5,9 +5,9 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-ARG APP_DIR="group_loader"
-ARG COMMON_DIR="common"
-ARG DATA_ACCESS_DIR="data_access"
+ARG APP_DIR="modules/group_loader"
+ARG COMMON_DIR="modules/common"
+ARG DATA_ACCESS_DIR="modules/data_access"
 ARG CONTAINER_APP_DIR="/usr/src/app"
 ENV PYTHONPATH="${PYTHONPATH}:${CONTAINER_APP_DIR}"
 

--- a/modules/group_loader/build_tag_push_update.sh
+++ b/modules/group_loader/build_tag_push_update.sh
@@ -2,9 +2,9 @@
 #!/usr/bin/env bash
 image_name=group_loader
 tag=$(git rev-parse --short HEAD)
-cd ./modules
-docker build -t $image_name:latest -f ./group_loader/Dockerfile .
+#cd ./modules
+docker build -t $image_name:latest -f ./modules/group_loader/Dockerfile .
 docker tag $image_name quay.io/battelleecology/$image_name:$tag
 docker push quay.io/battelleecology/$image_name:$tag
-cd ..
+#cd ..
 Rscript ./utilities/flow.img.updt.R "./pipe" ".yaml" "quay.io/battelleecology/$image_name" "$tag"


### PR DESCRIPTION
For github actions to build the docker images and push to GCP's Artifact Registry, we need to build from the top level NEON-IS-data-processing