### PR TITLE
Choim nse10537 dockerenv

### DIFF
--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -111,5 +111,5 @@ runs:
           git tag ${{ env.MODULE_NAME }}/${{ env.SEM_VERSION }}
           git add  -u .
           git commit -m "pipeline yamls updated"  || echo "No yamls updated"
-          git push origin ${{ env.MODULE_NAME }}/${{ env.SEM_VERSION }}  || echo "No changes to commit"
+          git push origin   || echo "No changes to commit"
         

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -68,7 +68,6 @@ runs:
             tags: |
               type=semver,pattern={{version}}
               type=schedule
-           #   type=ref,event=branch
               type=ref,event=tag
               type=ref,event=pr
               type=sha

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -64,13 +64,13 @@ runs:
         with:
             images: |
               ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}
-              ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_NS }}/${{ env.REPO_NAME }}/modules/${{ env.MODULE_NAME }}
-            #tags: |
+         #     ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_NS }}/${{ env.REPO_NAME }}/modules/${{ env.MODULE_NAME }}
+            tags: |
             # type=schedule
             # type=ref,event=branch
             # type=ref,event=tag
             # type=ref,event=pr
-            # type=short_sha
+              type=short_sha
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -79,9 +79,11 @@ runs:
         uses: docker/build-push-action@v5
         with:
             context: .
-            push: ${{ github.event_name != 'pull_request' }}
-            tags: ${{ steps.meta.outputs.tags }}
-            labels: ${{ steps.meta.outputs.labels }}
+       #     push: ${{ github.event_name != 'pull_request' }}
+       #     tags: ${{ steps.meta.outputs.tags }}
+            tags: ${{ inputs.image-tag }}
+       
+       #     labels: ${{ steps.meta.outputs.labels }}
        
       - name: Set up R
         uses: r-lib/actions/setup-r@v2

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -36,7 +36,7 @@ runs:
 
       - name: Push image
         shell: bash
-        run: docker push ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }} --all-tags
+        run: docker push ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.image-tag }}
 
       - name: Set up R
         uses: r-lib/actions/setup-r@v2

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -39,12 +39,12 @@ runs:
       #   run: docker push ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.image-tag }}
 
       # Login to google artifact registry
-      - name: Log into registry ${{ env.GCP_ARTIFACT_HOST }}
-        uses: 'docker/login-action@v3'
-        with:
-            registry: ${{ env.GCP_ARTIFACT_HOST }}
-            username: 'oauth2accesstoken'
-            password: ${{ steps.auth.outputs.access_token }}
+      # - name: Log into registry ${{ env.GCP_ARTIFACT_HOST }}
+      #   uses: 'docker/login-action@v3'
+      #   with:
+      #       registry: ${{ env.GCP_ARTIFACT_HOST }}
+      #       username: 'oauth2accesstoken'
+      #       password: ${{ steps.auth.outputs.access_token }}
            
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -22,40 +22,6 @@ runs:
         shell: bash
         run: gcloud auth configure-docker ${{ env.GCP_ARTIFACT_HOST }} --quiet
 
-      # - name: Build image
-      #   shell: bash
-      #   run: docker build -t ${{ env.IMAGE_NAME }}:latest -f ./modules/${{ env.MODULE_NAME }}/Dockerfile .
-      # 
-      # - name: Tag image with short SHA
-      #   shell: bash
-      #   run: docker tag ${{ env.IMAGE_NAME }}  ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.image-tag }} 
-      # 
-      # - name: Tag image with semantic version
-      #   shell: bash
-      #   run: docker tag ${{ env.IMAGE_NAME }}  ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.SEM_VERSION }}
-      # 
-      # - name: Push image
-      #   shell: bash
-      #   run: docker push ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.image-tag }}
-
-      # Login to google artifact registry
-      # - name: Log into registry ${{ env.GCP_ARTIFACT_HOST }}
-      #   uses: 'docker/login-action@v3'
-      #   with:
-      #       registry: ${{ env.GCP_ARTIFACT_HOST }}
-      #       username: 'oauth2accesstoken'
-      #       password: ${{ steps.auth.outputs.access_token }}
-           
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      # - name: Log into registry ${{ env.REGISTRY }}
-      #   if: github.event_name != 'pull_request'
-      #   uses: docker/login-action@v3
-      #   with:
-      #       registry: ${{ env.REGISTRY }}
-      #       username: ${{ github.actor }}
-      #       password: ${{ env.GITHUB_TOKEN }}
-
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
@@ -64,7 +30,6 @@ runs:
         with:
             images: |
               ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}
-         #     ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_NS }}/${{ env.REPO_NAME }}/modules/${{ env.MODULE_NAME }}
             tags: |
               type=semver,pattern={{version}}
               type=schedule

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -81,7 +81,7 @@ runs:
             context: .
        #     push: ${{ github.event_name != 'pull_request' }}
        #     tags: ${{ steps.meta.outputs.tags }}
-            tags: ${{ inputs.image-tag }}
+            tags: ${{ env.SEM_VERSION }}
        
        #     labels: ${{ steps.meta.outputs.labels }}
        

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -18,9 +18,9 @@ runs:
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v2"
 
-      # - name: "Docker auth"
-      #   shell: bash
-      #   run: gcloud auth configure-docker ${{ env.GCP_ARTIFACT_HOST }} --quiet
+      - name: "Docker auth"
+        shell: bash
+        run: gcloud auth configure-docker ${{ env.GCP_ARTIFACT_HOST }} --quiet
 
       # - name: Build image
       #   shell: bash
@@ -68,7 +68,7 @@ runs:
             tags: |
               type=semver,pattern={{version}}
               type=schedule
-              type=ref,event=branch
+           #   type=ref,event=branch
               type=ref,event=tag
               type=ref,event=pr
               type=sha

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -65,12 +65,12 @@ runs:
             images: |
               ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}
          #     ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_NS }}/${{ env.REPO_NAME }}/modules/${{ env.MODULE_NAME }}
-            tags: |
+         #   tags: |
             # type=schedule
             # type=ref,event=branch
             # type=ref,event=tag
             # type=ref,event=pr
-              type=short_sha
+            # type=short_sha
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -18,26 +18,71 @@ runs:
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v2"
 
-      - name: "Docker auth"
-        shell: bash
-        run: gcloud auth configure-docker ${{ env.GCP_ARTIFACT_HOST }} --quiet
+      # - name: "Docker auth"
+      #   shell: bash
+      #   run: gcloud auth configure-docker ${{ env.GCP_ARTIFACT_HOST }} --quiet
 
-      - name: Build image
-        shell: bash
-        run: docker build -t ${{ env.IMAGE_NAME }}:latest -f ./modules/${{ env.MODULE_NAME }}/Dockerfile .
+      # - name: Build image
+      #   shell: bash
+      #   run: docker build -t ${{ env.IMAGE_NAME }}:latest -f ./modules/${{ env.MODULE_NAME }}/Dockerfile .
+      # 
+      # - name: Tag image with short SHA
+      #   shell: bash
+      #   run: docker tag ${{ env.IMAGE_NAME }}  ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.image-tag }} 
+      # 
+      # - name: Tag image with semantic version
+      #   shell: bash
+      #   run: docker tag ${{ env.IMAGE_NAME }}  ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.SEM_VERSION }}
+      # 
+      # - name: Push image
+      #   shell: bash
+      #   run: docker push ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.image-tag }}
 
-      - name: Tag image with short SHA
-        shell: bash
-        run: docker tag ${{ env.IMAGE_NAME }}  ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.image-tag }} 
- 
-      - name: Tag image with semantic version
-        shell: bash
-        run: docker tag ${{ env.IMAGE_NAME }}  ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.SEM_VERSION }}
+      # Login to google artifact registry
+       - name: Log into registry ${{ env.GCP_ARTIFACT_HOST }}
+         uses: 'docker/login-action@v3'
+         with:
+           registry: ${{ env.GCP_ARTIFACT_HOST }}
+           username: 'oauth2accesstoken'
+           password: ${{ steps.auth.outputs.access_token }}
+           
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+       - name: Log into registry ${{ env.REGISTRY }}
+         if: github.event_name != 'pull_request'
+       uses: docker/login-action@v3
+       with:
+         registry: ${{ env.REGISTRY }}
+         username: ${{ github.actor }}
+         password: ${{ env.GITHUB_TOKEN }}
 
-      - name: Push image
-        shell: bash
-        run: docker push ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.image-tag }}
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}
+            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_NS }}/${{ env.REPO_NAME }}/modules/${{ env.MODULE_NAME }}
+          tags: |
+            # type=schedule
+            # type=ref,event=branch
+            # type=ref,event=tag
+            # type=ref,event=pr
+            type=sha
 
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+       
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
         

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -65,12 +65,13 @@ runs:
             images: |
               ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}
          #     ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_NS }}/${{ env.REPO_NAME }}/modules/${{ env.MODULE_NAME }}
-         #   tags: |
+            tags: |
+              type=semver,pattern={{version}}
             # type=schedule
             # type=ref,event=branch
             # type=ref,event=tag
             # type=ref,event=pr
-            # type=short_sha
+            # type=sha
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -80,8 +81,8 @@ runs:
         with:
             context: .
        #     push: ${{ github.event_name != 'pull_request' }}
-       #     tags: ${{ steps.meta.outputs.tags }}
-            tags: ${{ env.SEM_VERSION }}
+              tags: ${{ steps.meta.outputs.tags }}
+       #     tags: ${{ env.SEM_VERSION }}
        
        #     labels: ${{ steps.meta.outputs.labels }}
        
@@ -110,5 +111,5 @@ runs:
           git tag ${{ env.MODULE_NAME }}/${{ env.SEM_VERSION }}
           git add  -u .
           git commit -m "pipeline yamls updated"  || echo "No yamls updated"
-  #        git push origin ${{ env.MODULE_NAME }}/${{ env.SEM_VERSION }}  || echo "No changes to commit"
+          git push origin ${{ env.MODULE_NAME }}/${{ env.SEM_VERSION }}  || echo "No changes to commit"
         

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -48,13 +48,13 @@ runs:
            
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-            registry: ${{ env.REGISTRY }}
-            username: ${{ github.actor }}
-            password: ${{ env.GITHUB_TOKEN }}
+      # - name: Log into registry ${{ env.REGISTRY }}
+      #   if: github.event_name != 'pull_request'
+      #   uses: docker/login-action@v3
+      #   with:
+      #       registry: ${{ env.REGISTRY }}
+      #       username: ${{ github.actor }}
+      #       password: ${{ env.GITHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -21,6 +21,10 @@ runs:
       - name: "Docker auth"
         shell: bash
         run: gcloud auth configure-docker ${{ env.GCP_ARTIFACT_HOST }} --quiet
+        
+      # setup-buildx-action for Docker
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -81,7 +81,7 @@ runs:
         with:
             context: .
        #     push: ${{ github.event_name != 'pull_request' }}
-              tags: ${{ steps.meta.outputs.tags }}
+            tags: ${{ steps.meta.outputs.tags }}
        #     tags: ${{ env.SEM_VERSION }}
        
        #     labels: ${{ steps.meta.outputs.labels }}

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -48,8 +48,6 @@ runs:
             tags: ${{ steps.meta.outputs.tags }}
             labels: ${{ steps.meta.outputs.labels }}
        
-       #     labels: ${{ steps.meta.outputs.labels }}
-       
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
         

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -67,11 +67,11 @@ runs:
          #     ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_NS }}/${{ env.REPO_NAME }}/modules/${{ env.MODULE_NAME }}
             tags: |
               type=semver,pattern={{version}}
-            # type=schedule
-            # type=ref,event=branch
-            # type=ref,event=tag
-            # type=ref,event=pr
-            # type=sha
+              type=schedule
+              type=ref,event=branch
+              type=ref,event=tag
+              type=ref,event=pr
+              type=sha
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -80,9 +80,9 @@ runs:
         uses: docker/build-push-action@v5
         with:
             context: .
-       #     push: ${{ github.event_name != 'pull_request' }}
+            push: ${{ github.event_name != 'pull_request' }}
             tags: ${{ steps.meta.outputs.tags }}
-       #     tags: ${{ env.SEM_VERSION }}
+            labels: ${{ steps.meta.outputs.labels }}
        
        #     labels: ${{ steps.meta.outputs.labels }}
        

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -39,22 +39,22 @@ runs:
       #   run: docker push ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ inputs.image-tag }}
 
       # Login to google artifact registry
-       - name: Log into registry ${{ env.GCP_ARTIFACT_HOST }}
-         uses: 'docker/login-action@v3'
-         with:
-           registry: ${{ env.GCP_ARTIFACT_HOST }}
-           username: 'oauth2accesstoken'
-           password: ${{ steps.auth.outputs.access_token }}
+      - name: Log into registry ${{ env.GCP_ARTIFACT_HOST }}
+        uses: 'docker/login-action@v3'
+        with:
+            registry: ${{ env.GCP_ARTIFACT_HOST }}
+            username: 'oauth2accesstoken'
+            password: ${{ steps.auth.outputs.access_token }}
            
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
-       - name: Log into registry ${{ env.REGISTRY }}
-         if: github.event_name != 'pull_request'
-       uses: docker/login-action@v3
-       with:
-         registry: ${{ env.REGISTRY }}
-         username: ${{ github.actor }}
-         password: ${{ env.GITHUB_TOKEN }}
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+            registry: ${{ env.REGISTRY }}
+            username: ${{ github.actor }}
+            password: ${{ env.GITHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
@@ -62,15 +62,15 @@ runs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: |
-            ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}
-            ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_NS }}/${{ env.REPO_NAME }}/modules/${{ env.MODULE_NAME }}
-          tags: |
+            images: |
+              ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}
+              ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_NS }}/${{ env.REPO_NAME }}/modules/${{ env.MODULE_NAME }}
+            tags: |
             # type=schedule
             # type=ref,event=branch
             # type=ref,event=tag
             # type=ref,event=pr
-            type=sha
+              type=sha
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -78,10 +78,10 @@ runs:
         id: build-and-push
         uses: docker/build-push-action@v5
         with:
-          context: .
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+            context: .
+            push: ${{ github.event_name != 'pull_request' }}
+            tags: ${{ steps.meta.outputs.tags }}
+            labels: ${{ steps.meta.outputs.labels }}
        
       - name: Set up R
         uses: r-lib/actions/setup-r@v2

--- a/.github/actions/build-push-update/action.yml
+++ b/.github/actions/build-push-update/action.yml
@@ -65,12 +65,12 @@ runs:
             images: |
               ${{ env.GCP_REGISTRY }}/${{ env.IMAGE_NAME }}
               ${{ env.GHCR_REGISTRY }}/${{ env.GHCR_NS }}/${{ env.REPO_NAME }}/modules/${{ env.MODULE_NAME }}
-            tags: |
+            #tags: |
             # type=schedule
             # type=ref,event=branch
             # type=ref,event=tag
             # type=ref,event=pr
-              type=sha
+            # type=short_sha
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action

--- a/.github/workflows/neon-is-group-loader.yml
+++ b/.github/workflows/neon-is-group-loader.yml
@@ -12,6 +12,7 @@ env:
   GCP_PROVIDER:  ${{ vars.SHARED_WIF_PROVIDER }}
   GCP_SERVICE_ACCOUNT: ${{ vars.SHARED_WIF_SERVICE_ACCOUNT }}
   GHCR_NS: battelleecology
+  #GHCR_NS: NEONScience
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
@@ -22,7 +23,7 @@ env:
   MODULE_NAME: group_loader
   IMAGE_NAME: neon-is-group-loader
   # git tag
-  SEM_VERSION: v1.1.8
+  SEM_VERSION: v1.2.0
 
 jobs:
   deploy:

--- a/.github/workflows/neon-is-location-loader.yml
+++ b/.github/workflows/neon-is-location-loader.yml
@@ -22,7 +22,7 @@ env:
   MODULE_NAME: location_loader
   IMAGE_NAME: neon-is-location-loader
   # git tag
-  SEM_VERSION: v1.2.0
+  SEM_VERSION: v1.2.4
 
 jobs:
   deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+####
+# This dockerfile will build the group loader module.
+# Example command (must be run from project root directory to include common path in Docker context):
+# docker build -t group_loader:latest -f group_loader/Dockerfile .
+###
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+ARG APP_DIR="modules/group_loader"
+ARG COMMON_DIR="modules/common"
+ARG DATA_ACCESS_DIR="modules/data_access"
+ARG CONTAINER_APP_DIR="/usr/src/app"
+ENV PYTHONPATH="${PYTHONPATH}:${CONTAINER_APP_DIR}"
+
+WORKDIR ${CONTAINER_APP_DIR}
+
+COPY ${APP_DIR}/requirements.txt ${CONTAINER_APP_DIR}/${APP_DIR}/app-requirements.txt
+COPY ${DATA_ACCESS_DIR}/requirements.txt ${CONTAINER_APP_DIR}/${APP_DIR}/data-access-requirements.txt
+
+RUN update-ca-trust && \
+    microdnf update -y --disableplugin=subscription-manager && \
+    microdnf install -y --disableplugin=subscription-manager \
+            shadow-utils \
+            gcc \
+            libzstd  \
+            python39 \
+            python39-pip \
+            python39-wheel \
+            python39-devel \
+            python39-setuptools && \
+    python3 -mpip install --no-cache-dir --upgrade pip setuptools wheel && \
+    python3 -mpip install --no-cache-dir -r ${CONTAINER_APP_DIR}/${APP_DIR}/app-requirements.txt && \
+    python3 -mpip install --no-cache-dir -r ${CONTAINER_APP_DIR}/${APP_DIR}/data-access-requirements.txt && \
+    microdnf remove -y --disableplugin=subscription-manager gcc cpp && \
+    microdnf clean all --disableplugin=subscription-manager && \
+    groupadd -g 9999 appuser && \
+    useradd -r -u 9999 -g appuser appuser
+
+COPY ${APP_DIR} ${CONTAINER_APP_DIR}/${APP_DIR}
+COPY ${COMMON_DIR} ${CONTAINER_APP_DIR}/${COMMON_DIR}
+COPY ${DATA_ACCESS_DIR} ${CONTAINER_APP_DIR}/${DATA_ACCESS_DIR}
+
+USER appuser

--- a/modules/location_loader/Dockerfile
+++ b/modules/location_loader/Dockerfile
@@ -7,7 +7,7 @@
 ###
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-ARG APP_DIR="location_loader"
+ARG APP_DIR="modules/location_loader"
 ARG COMMON_DIR="modules/common"
 ARG DATA_ACCESS_DIR="modules/data_access"
 ARG CONTAINER_APP_DIR="/usr/src/app"

--- a/modules/location_loader/Dockerfile
+++ b/modules/location_loader/Dockerfile
@@ -8,8 +8,8 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 ARG APP_DIR="location_loader"
-ARG COMMON_DIR="common"
-ARG DATA_ACCESS_DIR="data_access"
+ARG COMMON_DIR="modules/common"
+ARG DATA_ACCESS_DIR="modules/data_access"
 ARG CONTAINER_APP_DIR="/usr/src/app"
 ENV PYTHONPATH="${PYTHONPATH}:${CONTAINER_APP_DIR}"
 

--- a/modules/location_loader/build_tag_push_update.sh
+++ b/modules/location_loader/build_tag_push_update.sh
@@ -2,9 +2,7 @@
 #!/usr/bin/env bash
 image_name=location_loader
 tag=$(git rev-parse --short HEAD)
-cd ./modules
-docker build --no-cache -t $image_name:latest -f ./location_loader/Dockerfile .
+docker build --no-cache -t $image_name:latest -f ./modules/location_loader/Dockerfile .
 docker tag $image_name quay.io/battelleecology/$image_name:$tag
 docker push quay.io/battelleecology/$image_name:$tag
-cd ..
 Rscript ./utilities/flow.img.updt.R "./pipe" ".yaml" "quay.io/battelleecology/$image_name" "$tag"

--- a/pipe/turbulent/turbulent_group_loader.yaml
+++ b/pipe/turbulent/turbulent_group_loader.yaml
@@ -9,7 +9,7 @@ transform:
     OUT_PATH: /pfs/out    
     # ERR_PATH can be changed, it is user specified
     ERR_PATH: /pfs/out/errored_datums
-  image: us-central1-docker.pkg.dev/neon-shared-service/neonscience/neon-is-group-loader:41d265d
+  image: us-central1-docker.pkg.dev/neon-shared-service/neonscience/neon-is-group-loader:9c657ca
   image_pull_secrets:
     - battelleecology-quay-read-all-pull-secret
   secrets:


### PR DESCRIPTION

Hi @covesturtevant, 

This PR has the followings:
- the action file is updated to use docker setup-buildx-action, metadata-action, build-push-action. 
- build_tag_push_update script is updated to work on the GCP and on-prem.  
- Dockerfile is created in the same level as .github/, this is the default location when docker metadata-action is called.  For now, only group_loader works due to the default Dockerfile path issue. 
(I am looking in to see if there is an option for a user to specify the Dockerfile path.)


FYI: NSE-10565 is created to track this,  
"Semantic version comes from a user-created git tag matching the format expected for this module.
Update of the pipeline specs is done in a new branch. PR created to integrated new branch to master."
  