### PR TITLE
Avoid numpy 2.0.1 bug

### DIFF
--- a/modules/pub_egress/requirements.txt
+++ b/modules/pub_egress/requirements.txt
@@ -2,3 +2,4 @@ structlog==21.5.0
 environs==6.0.0
 python-dateutil==2.8.1
 pandas==1.2.5
+numpy==1.26.4


### PR DESCRIPTION
Avoid numpy 2.0.1 bug. tested successfully with parQuantumline.