### PR TITLE
update neon-avro-kafka-loader tag

### DIFF
--- a/pipe/aepg600m/aepg600m_data_source_kafka.yaml
+++ b/pipe/aepg600m/aepg600m_data_source_kafka.yaml
@@ -152,7 +152,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 300M
-  cpu: 1.3
+  cpu: 1.6
 resource_limits:
   memory: 1.5G
   cpu: 2

--- a/pipe/aepg600m/aepg600m_data_source_kafka.yaml
+++ b/pipe/aepg600m/aepg600m_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: aepg600m_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/cmp22/cmp22_data_source_kafka.yaml
+++ b/pipe/cmp22/cmp22_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: cmp22_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/cmp22/cmp22_data_source_kafka.yaml
+++ b/pipe/cmp22/cmp22_data_source_kafka.yaml
@@ -149,7 +149,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 300M
-  cpu: 1.3
+  cpu: 1.6
 resource_limits:
   memory: 1.5G
   cpu: 2

--- a/pipe/dualfan/dualfan_data_source_kafka.yaml
+++ b/pipe/dualfan/dualfan_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: dualfan_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/dualfan/dualfan_data_source_kafka.yaml
+++ b/pipe/dualfan/dualfan_data_source_kafka.yaml
@@ -149,7 +149,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 300M
-  cpu: 1.3
+  cpu: 1.6
 resource_limits:
   memory: 1.5G
   cpu: 2

--- a/pipe/g2131i_raw/g2131i_raw_data_source_kafka.yaml
+++ b/pipe/g2131i_raw/g2131i_raw_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: g2131i_raw_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/g2131i_raw/g2131i_raw_data_source_kafka.yaml
+++ b/pipe/g2131i_raw/g2131i_raw_data_source_kafka.yaml
@@ -149,7 +149,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 300M
-  cpu: 1.3
+  cpu: 1.6
 resource_limits:
   memory: 1.5G
   cpu: 2

--- a/pipe/hmp155/hmp155_data_source_kafka.yaml
+++ b/pipe/hmp155/hmp155_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: hmp155_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/hmp155/hmp155_data_source_kafka.yaml
+++ b/pipe/hmp155/hmp155_data_source_kafka.yaml
@@ -149,7 +149,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 300M
-  cpu: 1.3
+  cpu: 1.6
 resource_limits:
   memory: 1.5G
   cpu: 2

--- a/pipe/l2130i_raw/l2130i_raw_data_source_kafka.yaml
+++ b/pipe/l2130i_raw/l2130i_raw_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: l2130i_raw_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/l2130i_raw/l2130i_raw_data_source_kafka.yaml
+++ b/pipe/l2130i_raw/l2130i_raw_data_source_kafka.yaml
@@ -149,7 +149,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 300M
-  cpu: 1.3
+  cpu: 1.6
 resource_limits:
   memory: 1.5G
   cpu: 2

--- a/pipe/li191r/li191r_data_source_kafka.yaml
+++ b/pipe/li191r/li191r_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: li191r_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/li191r/li191r_data_source_kafka.yaml
+++ b/pipe/li191r/li191r_data_source_kafka.yaml
@@ -149,7 +149,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 300M
-  cpu: 1.3
+  cpu: 1.6
 resource_limits:
   memory: 1.5G
   cpu: 2

--- a/pipe/li7200/li7200_data_source_kafka.yaml
+++ b/pipe/li7200/li7200_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: li7200_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/mcseries/mcseries_data_source_kafka.yaml
+++ b/pipe/mcseries/mcseries_data_source_kafka.yaml
@@ -149,7 +149,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 1G
-  cpu: 1.5
+  cpu: 1.6
 resource_limits:
   memory: 3G
   cpu: 3

--- a/pipe/mcseries/mcseries_data_source_kafka.yaml
+++ b/pipe/mcseries/mcseries_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: mcseries_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/metone370380/metone370380_event_data_source_kafka.yaml
+++ b/pipe/metone370380/metone370380_event_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: metone370380_event_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/mti300ahrs/mti300ahrs_data_source_kafka.yaml
+++ b/pipe/mti300ahrs/mti300ahrs_data_source_kafka.yaml
@@ -149,7 +149,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 2G
-  cpu: 1.5
+  cpu: 1.6
 resource_limits:
   memory: 5G
   cpu: 4

--- a/pipe/mti300ahrs/mti300ahrs_data_source_kafka.yaml
+++ b/pipe/mti300ahrs/mti300ahrs_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: mti300ahrs_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/nr01/nr01_data_source_kafka.yaml
+++ b/pipe/nr01/nr01_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: nr01_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/nr01/nr01_data_source_kafka.yaml
+++ b/pipe/nr01/nr01_data_source_kafka.yaml
@@ -149,7 +149,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 300M
-  cpu: 1.3
+  cpu: 1.6
 resource_limits:
   memory: 1.5G
   cpu: 2

--- a/pipe/pluvio_testing/pluvio_data_source_kafka.yaml
+++ b/pipe/pluvio_testing/pluvio_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: pluvio_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/pluvio_testing/pluvio_data_source_kafka.yaml
+++ b/pipe/pluvio_testing/pluvio_data_source_kafka.yaml
@@ -135,7 +135,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 300M
-  cpu: 1.3
+  cpu: 1.6
 resource_limits:
   memory: 1.5G
   cpu: 2

--- a/pipe/pqs1/pqs1_data_source_kafka.yaml
+++ b/pipe/pqs1/pqs1_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: pqs1_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/pqs1/pqs1_data_source_kafka.yaml
+++ b/pipe/pqs1/pqs1_data_source_kafka.yaml
@@ -149,7 +149,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 300M
-  cpu: 1.3
+  cpu: 1.6
 resource_limits:
   memory: 1.5G
   cpu: 2

--- a/pipe/pressuretransducer/pressuretransducer_data_source_kafka.yaml
+++ b/pipe/pressuretransducer/pressuretransducer_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: pressuretransducer_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/pressuretransducer/pressuretransducer_data_source_kafka.yaml
+++ b/pipe/pressuretransducer/pressuretransducer_data_source_kafka.yaml
@@ -149,7 +149,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 1G
-  cpu: 1.5
+  cpu: 1.6
 resource_limits:
   memory: 3G
   cpu: 3

--- a/pipe/prt/prt_data_source_kafka.yaml
+++ b/pipe/prt/prt_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: prt_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/prt/prt_data_source_kafka.yaml
+++ b/pipe/prt/prt_data_source_kafka.yaml
@@ -149,7 +149,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 300M
-  cpu: 1.3
+  cpu: 1.6
 resource_limits:
   memory: 1.5G
   cpu: 2

--- a/pipe/ptb330a/ptb330a_data_source_kafka.yaml
+++ b/pipe/ptb330a/ptb330a_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: ptb330a_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/ptb330a/ptb330a_data_source_kafka.yaml
+++ b/pipe/ptb330a/ptb330a_data_source_kafka.yaml
@@ -149,7 +149,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 300M
-  cpu: 1.3
+  cpu: 1.6
 resource_limits:
   memory: 1.5G
   cpu: 2

--- a/pipe/sandbox/ONEOFF_level0_bucket_compact.yaml
+++ b/pipe/sandbox/ONEOFF_level0_bucket_compact.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: ONEOFF_level0_bucket_compact
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   cmd:
   - sh
   - "-c"

--- a/pipe/stevenshp/stevenshp_data_source_kafka.yaml
+++ b/pipe/stevenshp/stevenshp_data_source_kafka.yaml
@@ -152,7 +152,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 300M
-  cpu: 1.3
+  cpu: 1.6
 resource_limits:
   memory: 1.5G
   cpu: 2

--- a/pipe/stevenshp/stevenshp_data_source_kafka.yaml
+++ b/pipe/stevenshp/stevenshp_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: stevenshp_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/troll/troll_data_source_kafka.yaml
+++ b/pipe/troll/troll_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: troll_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/troll/troll_data_source_kafka.yaml
+++ b/pipe/troll/troll_data_source_kafka.yaml
@@ -151,7 +151,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 300M
-  cpu: 1.3
+  cpu: 1.6
 resource_limits:
   memory: 1.5G
   cpu: 2

--- a/pipe/windobserverii/windobserverii_data_source_kafka.yaml
+++ b/pipe/windobserverii/windobserverii_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: windobserverii_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:

--- a/pipe/windobserverii/windobserverii_data_source_kafka.yaml
+++ b/pipe/windobserverii/windobserverii_data_source_kafka.yaml
@@ -149,7 +149,7 @@ parallelism_spec:
 autoscaling: true
 resource_requests:
   memory: 300M
-  cpu: 1.3
+  cpu: 1.6
 resource_limits:
   memory: 1.5G
   cpu: 2

--- a/pipe/windobserverii_extreme/windobserverii_extreme_data_source_kafka.yaml
+++ b/pipe/windobserverii_extreme/windobserverii_extreme_data_source_kafka.yaml
@@ -2,7 +2,7 @@
 pipeline:
   name: windobserverii_extreme_data_source_kafka
 transform:
-  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-413746d
+  image: us-central1-docker.pkg.dev/neon-shared-service/bei/neon-avro-kafka-loader:sha-33a37dd
   image_pull_secrets:
   - battelleecology-quay-read-all-pull-secret
   env:


### PR DESCRIPTION
loader now removes DFIR suffix from site names for airflow table