### PR TITLE
Add GH Actions workflow to build envscn cal-depth-ref image

### DIFF
--- a/.github/workflows/build_push_envscn_cal_depth_ref.yml
+++ b/.github/workflows/build_push_envscn_cal_depth_ref.yml
@@ -1,0 +1,42 @@
+name: "Build-push_flow.envscn.cal.depth.ref"
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'flow/flow.envscn.cal.depth.ref/**'
+  workflow_dispatch: {} # Allows trigger of workflow from web interface
+
+env:
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN }}
+  GHCR_REGISTRY: ghcr.io
+  GCP_ARTIFACT_HOST: ${{ vars.SHARED_WIF_LOCATON }}-docker.pkg.dev
+  GCP_REGISTRY: ${{ vars.SHARED_WIF_LOCATON }}-docker.pkg.dev/${{ vars.SHARED_WIF_PROJECT }}/${{ vars.SHARED_WIF_REPO }}
+  GCP_PROVIDER:  ${{ vars.SHARED_WIF_PROVIDER }}
+  GCP_SERVICE_ACCOUNT: ${{ vars.SHARED_WIF_SERVICE_ACCOUNT }}
+  GHCR_NS: battelleecology
+  REGISTRY: ghcr.io
+  REPO_NAME: ${{ github.event.repository.name }}
+  MODULE_PATH: ./flow/flow.envscn.cal.depth.ref
+  IMAGE_NAME: neon-is-envscn-cal-depth-ref
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    permissions:
+        contents: 'write'
+        id-token: 'write'
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4.1.4"
+        with:
+          fetch-depth: '0'
+
+      - name: Get short SHA
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: ./.github/actions/build-push
+        with:
+            image-tag: "${short_sha}"


### PR DESCRIPTION
Adds .github/workflows/build_push_envscn_cal_depth_ref.yml which builds the neon-is-envscn-cal-depth-ref image used by an upcoming concH2oSoilSalinity sidecar step. The corresponding flow module code lives on swc_loc_depths; merging this workflow to master first makes workflow_dispatch available so that branch's image can be built.