### PR TITLE
marshmallow requirement failure

### DIFF
--- a/modules/location_asset_loader/requirements.txt
+++ b/modules/location_asset_loader/requirements.txt
@@ -1,3 +1,4 @@
 structlog==21.5.0
 geojson==2.4.1
 environs==6.0.0
+marshmallow<4

--- a/modules/location_asset_loader/requirements.txt
+++ b/modules/location_asset_loader/requirements.txt
@@ -1,4 +1,3 @@
 structlog==21.5.0
 geojson==2.4.1
-environs==6.0.0
-marshmallow<4
+environs==11.0.0


### PR DESCRIPTION
marshmallow not being explicitly called breaks on a versions error. Either need lower marshmallow explicitly added or bumping environs to 11 or higher. 

Claude recommended doing lower marshmallows for this one as it was less of potential change code-wise. 
